### PR TITLE
Optional token injection by nginx server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,7 @@ RUN mkdir -p /var/tmp/nginx
 COPY --from=builder /app/build /usr/share/nginx/html
 WORKDIR /root
 COPY nginx.conf .
+COPY setup_nginx_conf.sh .
+RUN chmod +x ./setup_nginx_conf.sh
 EXPOSE 8080
-ENTRYPOINT ["/bin/bash", "-c", "envsubst '$FLOWIFY_SERVER_PORT $FLOWIFY_SERVER_HOST' < /root/nginx.conf > /etc/nginx/nginx.conf && nginx -g 'daemon off;'"]
+ENTRYPOINT ["/bin/bash", "-c", "/root/setup_nginx_conf.sh && nginx -g 'daemon off;'"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -39,6 +39,7 @@ http {
             add_header 'Access-Control-Allow-Headers' 'Authorization,Accept,Origin,DNT,X-CustomHeader,Keep-Alive,User-Agent,
             X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
             add_header 'Access-Control-Allow-Methods' 'GET,POST,OPTIONS,PUT,DELETE,PATCH';
+            # flowify_token_auth
             proxy_pass http://${FLOWIFY_SERVER_HOST}:${FLOWIFY_SERVER_PORT}/api;
         }
     }

--- a/setup_nginx_conf.sh
+++ b/setup_nginx_conf.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+input_file="/root/nginx.conf"
+output_file="/etc/nginx/nginx.conf"
+
+nginx_config=`cat $input_file`
+
+if [[ -v FLOWIFY_AUTH_TOKEN ]];
+then
+    flowify_token_auth="proxy_set_header Authorization '$FLOWIFY_AUTH_TOKEN';\n            proxy_pass_header Authorization;"
+    nginx_config=$(sed "/# flowify_token_auth/a \            $flowify_token_auth" <<< $nginx_config)
+fi
+
+envsubst '$FLOWIFY_SERVER_PORT $FLOWIFY_SERVER_HOST' <<< $nginx_config > $output_file
+
+echo done


### PR DESCRIPTION
Token from the environmental variable `FLOWIFY_AUTH_TOKEN` will be injected by the nginx reverse proxy for authorization.

Container can be run with command:
```
docker run -d --rm --name flowify_ui -p 8080:8080 --network kind -e FLOWIFY_AUTH_TOKEN="Bearer <token>" dev_frontend
```

or (using host env. var.):
```
export FLOWIFY_AUTH_TOKEN="Bearer ..."
docker run -d --rm --name flowify_ui -p 8080:8080 --network kind -e FLOWIFY_AUTH_TOKEN dev_frontend
```