### PR TITLE
Support for new role distribution in workspaces

### DIFF
--- a/src/auth.tsx
+++ b/src/auth.tsx
@@ -49,7 +49,7 @@ export function WorkspaceAuth(props: { children: React.ReactNode }) {
     );
   }
   // Does user have access to workspace
-  if (!workspace.hasAccess) {
+  if (workspace.roles && workspace?.roles?.length === 0) {
     return (
       <Layout>
         <Container withMargins>You do not have access to the {workspaceName} workspace.</Container>

--- a/src/common/context/user-context-store.tsx
+++ b/src/common/context/user-context-store.tsx
@@ -12,19 +12,26 @@ interface IUserProps {
   userInfo: UserInfo;
   // dispatch: Dispatch<Actions>;
   setUserInfo: Dispatch<SetStateAction<UserInfo>>;
+  hasAnyAdminAccess: boolean;
 }
 
 export const UserContextStore = React.createContext({} as IUserProps);
 
 export function CurrentUserProvider(props: any) {
   const [userInfo, setUserInfo] = useState(initialUserState);
-  const value = { userInfo, setUserInfo };
+  const [hasAnyAdminAccess, setHasAnyAdminAccess] = useState(false);
+  const value = { userInfo, setUserInfo, hasAnyAdminAccess };
 
   useEffect(() => {
     services.userinfo
       .getUserInfo()
       .then((x) => setUserInfo(x))
       .catch((e) => {});
+
+    services.workspace.list().then((res) => {
+      const hasAccess = res.items?.some((workspace) => workspace?.roles?.includes('admin'));
+      setHasAnyAdminAccess(hasAccess);
+    });
   }, []);
 
   return <UserContextStore.Provider value={value}>{props.children}</UserContextStore.Provider>;

--- a/src/components/workspaces-listing/workspaces-listing.tsx
+++ b/src/components/workspaces-listing/workspaces-listing.tsx
@@ -3,6 +3,7 @@ import { Icon, Progress } from '@equinor/eds-core-react';
 import { services } from '../../services';
 import { Workspace } from '../../models/v2';
 import { DashboardListing } from '../listings/dashboard-listing';
+import { isNotEmptyArray } from '../../common';
 
 interface IWorkspacesListing {}
 
@@ -13,7 +14,7 @@ const WorkspacesListing: FC<IWorkspacesListing> = (props: IWorkspacesListing) =>
   useEffect(() => {
     function createWorkspacesLinkList(items: Workspace[]) {
       const list = items
-        .filter((item) => item.hasAccess)
+        .filter((item) => isNotEmptyArray(item?.roles))
         .map((item) => ({ title: item.name, url: `/workspace/${item.name}` }));
       return list;
     }

--- a/src/layout/header/header.tsx
+++ b/src/layout/header/header.tsx
@@ -1,12 +1,14 @@
-import React, { FC } from 'react';
+import React, { FC, useContext } from 'react';
 import { Icon, Typography } from '@equinor/eds-core-react';
 import { Link } from 'react-router-dom';
 import { FlowifyIcon, Stack } from '../../components/ui';
 import { TopBar, IconsWrapper } from './styles';
+import { UserContextStore } from '../../common/context/user-context-store';
 
 interface IHeader {}
 
 const Header: FC<IHeader> = (props: IHeader) => {
+  const { hasAnyAdminAccess } = useContext(UserContextStore);
   return (
     <TopBar>
       <Stack direction="row" alignItems="center" spacing={1}>
@@ -21,9 +23,11 @@ const Header: FC<IHeader> = (props: IHeader) => {
         <Link title="Marketplace" to="/components" className="ff-header__link">
           <Icon name="mall" size={24} />
         </Link>
-        <Link title="Admin page" to="/admin" className="ff-header__link">
-          <Icon name="verified_user" size={24} />
-        </Link>
+        {hasAnyAdminAccess && (
+          <Link title="Admin page" to="/admin" className="ff-header__link">
+            <Icon name="verified_user" size={24} />
+          </Link>
+        )}
         <Link title="User profile" to="/user" className="ff-header__link">
           <Icon name="account_circle" size={24} />
         </Link>

--- a/src/models/v2/workspace.ts
+++ b/src/models/v2/workspace.ts
@@ -11,8 +11,8 @@ export interface Role {
  */
 export interface Workspace {
   name: string;
-  hasAccess: boolean;
-  missingRoles: Role[][];
+  roles: string[];
+  description?: string;
 }
 
 /**

--- a/src/pages/admin/admin.tsx
+++ b/src/pages/admin/admin.tsx
@@ -11,6 +11,7 @@ import { VolumeEditor } from '../../components/editors/volume/volume-editor';
 import { Feedback, Feedbacks } from '../../components/editors/components';
 import { SecretEditor } from '../../components/editors/secret-editor/secret-editor';
 import { Select } from '../../components/form';
+import { isNotEmptyArray } from '../../common';
 
 function CREATE_VOLUME_TEMPLATE(workspace: string) {
   return {
@@ -104,7 +105,7 @@ export const AdminPage: React.FC = (): React.ReactElement => {
 
   const workspaceOptions =
     workspaces
-      ?.filter((workspace) => workspace.hasAccess)
+      ?.filter((workspace) => isNotEmptyArray(workspace.roles) && workspace?.roles?.includes('admin'))
       .map((workspace) => ({ label: workspace.name, value: workspace.name })) || [];
 
   return (


### PR DESCRIPTION
- New filtering on access role for workspaces
- Check if user has admin access to any workspace, set in context
- Only show admin page if check is true + Only show workspaces in dropdown that user has access to