### PR TITLE
Issue#93: Add UI component for deleting a workspace

### DIFF
--- a/src/components/creators/delete-workspace/delete-workspace.tsx
+++ b/src/components/creators/delete-workspace/delete-workspace.tsx
@@ -1,0 +1,105 @@
+import React, { FC, useState } from 'react';
+import { Button as EDSButton, Snackbar } from '@equinor/eds-core-react';
+import { Modal as OPTModal } from '@equinor/opt-ui-core';
+import { DeleteToTrash } from '@equinor/opt-ui-icons';
+import { Workspace } from '@models/v2';
+import { services } from '@services';
+import { Button } from '@ui';
+import { useUser, useWorkspaces } from '@common';
+import { Feedback,  Feedbacks } from '../../../components/editors/components/feedbacks/feedbacks';
+import { DeleteWorkspaceProps } from './types';
+
+const ErrorMessages = {
+  default: 'Could not delete a workspace.',
+};
+
+/**
+ * Delete workspace
+ * Modal that handles the deleting of a workspace.
+ * Handles user name setting, validation and api calls -> success notification.
+ */
+
+const DeleteWorkspace: FC<DeleteWorkspaceProps> = (props: DeleteWorkspaceProps) => {
+  const { workspace } = props;
+  const [modalOpen, setModalOpen] = useState<boolean>(false);
+  const [errorMessage, setErrorMessage] = useState<string>(ErrorMessages.default)
+  const [errorSnackbar, setErrorSnackbar] = useState<boolean>(false);
+  const [submitting, setSubmitting] = useState<boolean>(false);
+  const [feedback, setFeedback] = useState<Feedback>();
+  
+
+  const { getWorkspaceItem, resetWorkspacesTimestamp } = useWorkspaces();
+  const workspaceItem = getWorkspaceItem(workspace);
+
+  const { checkIfUserIsWorkspaceEditor } = useUser();
+  const showShareButton = checkIfUserIsWorkspaceEditor(workspaceItem);
+
+  if (!showShareButton) return null;
+
+  const onCloseError = () => {
+    setErrorMessage(ErrorMessages.default);
+    setErrorSnackbar(false);
+  };
+
+  const handleSubmit = (w: Workspace) => {
+    services.workspace
+    .delete(w)
+    .then((res) => {
+      if (res) {
+        setFeedback({ message: 'Workspace was deleted successfully.', type: 'success' });
+        setModalOpen(false);
+        setSubmitting(false);
+        resetWorkspacesTimestamp(null);
+      }
+    })
+    .catch((error) => {
+      console.error(error);
+      setSubmitting(false);
+      setErrorSnackbar(true);
+    });
+  };
+
+  function onSubmit() {
+    if (submitting) {
+      return;
+    }
+    setSubmitting(true);
+    if (workspaceItem) {
+        handleSubmit(workspaceItem);
+    }
+  }
+
+  return (
+    <>
+      <Feedbacks feedback={feedback} setFeedback={setFeedback} />
+      <Snackbar open={errorSnackbar} onClose={onCloseError}>
+        {errorMessage}
+        <Snackbar.Action>
+          <EDSButton onClick={onCloseError} variant="ghost">
+            Close
+          </EDSButton>
+        </Snackbar.Action>
+      </Snackbar>
+      <Button theme="danger" aria-label="Delete icon button" onClick={() => setModalOpen(true)}>
+        <DeleteToTrash />
+      </Button>
+      <OPTModal
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+        title="Workspace deleting"
+        footer={[
+          <Button key="modal_cancel" theme='simple' onClick={() => setModalOpen(false)}>
+            Cancel
+          </Button>,
+          <Button key="modal_save" theme='danger' onClick={onSubmit}>
+            Delete
+          </Button>
+        ]}
+      >
+        <p>Are you sure you want to delete the {workspace} workspace?</p>
+      </OPTModal>
+    </>
+  );
+};
+
+export default DeleteWorkspace;

--- a/src/components/creators/delete-workspace/types.ts
+++ b/src/components/creators/delete-workspace/types.ts
@@ -1,0 +1,3 @@
+export interface DeleteWorkspaceProps {
+  workspace: string;
+}

--- a/src/components/creators/index.tsx
+++ b/src/components/creators/index.tsx
@@ -2,4 +2,5 @@ export { default as CreateComponent } from './create-component/create-component'
 export { default as CreateWorkflow } from './create-workflow/create-workflow';
 export { default as CreateWorkspace } from './create-workspace/create-workspace';
 export { RunWorkflow } from './run-workflow/run-workflow';
-export { default as ShareWorkspace} from './share-workspace/share-workspace';
+export { default as ShareWorkspace } from './share-workspace/share-workspace';
+export { default as DeleteWorkspace } from './delete-workspace/delete-workspace';

--- a/src/components/creators/share-workspace/share-workspace.tsx
+++ b/src/components/creators/share-workspace/share-workspace.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useState } from 'react';
 import { Button as EDSButton, Snackbar } from '@equinor/eds-core-react';
-import { Modal as OPTModal, Button as OPTButton, RadioGroup, Radio } from '@equinor/opt-ui-core';
+import { Modal as OPTModal, RadioGroup, Radio } from '@equinor/opt-ui-core';
 import { Share } from '@equinor/opt-ui-icons';
 import { Form, Formik } from 'formik';
 import * as yup from 'yup';
@@ -146,11 +146,11 @@ const ShareWorkspace: FC<ShareWorkspaceProps> = (props: ShareWorkspaceProps) => 
           </EDSButton>
         </Snackbar.Action>
       </Snackbar>
-      <Button theme="create" aria-label="Share icon button" onClick={() => setModalOpen(true)}>
+      <Button theme="simple" aria-label="Share icon button" onClick={() => setModalOpen(true)}>
         <Share />
       </Button>
       <Modal maxWidth="sm" fullWidth open={modalOpen} onClose={() => setModalOpen(false)}>
-        <DialogWrapper padding={2}>
+        <DialogWrapper padding={2} basis='content'>
           <Formik
             onSubmit={onSubmit}
             initialValues={{
@@ -178,12 +178,12 @@ const ShareWorkspace: FC<ShareWorkspaceProps> = (props: ShareWorkspaceProps) => 
         onClose={onCloseWarning}
         title="Workspace sharing"
         footer={[
-          <OPTButton key="modal_cancel" variant="outlined" color="primary" onClick={onCloseWarning}>
+          <Button key="modal_cancel" theme='simple' onClick={onCloseWarning}>
             Cancel
-          </OPTButton>,
-          <OPTButton key="modal_save" onClick={onContinue}>
+          </Button>,
+          <Button key="modal_save" theme='create' onClick={onContinue}>
             Continue
-          </OPTButton>
+          </Button>
         ]}
       >
         <p>Are you sure you want to {warningMessage}?</p>

--- a/src/components/ui/modal/modal.tsx
+++ b/src/components/ui/modal/modal.tsx
@@ -21,7 +21,6 @@ export const Modal: FC<ModalProps> = (props: ModalProps) => {
 
   const customStyles: Styles = {
     content: {
-      minHeight: '60vh',
       top: '50%',
       left: '50%',
       right: 'auto',

--- a/src/pages/workspace/workspace.tsx
+++ b/src/pages/workspace/workspace.tsx
@@ -4,7 +4,7 @@ import { Helmet } from 'react-helmet-async';
 import { Container, Layout } from '../../layout';
 import { Stack, MultiToggle, ToggleButton, Breadcrumbs } from '@ui';
 import { WorkflowsListing, JobsListing } from '../../components';
-import { CreateWorkflow, ShareWorkspace } from '../../components/creators';
+import { CreateWorkflow, ShareWorkspace, DeleteWorkspace } from '../../components/creators';
 import { Icon } from '@equinor/eds-core-react';
 
 interface IWorkspace {}
@@ -22,7 +22,10 @@ const Workspace: FC<IWorkspace> = (props: IWorkspace) => {
         <Stack style={{ padding: '1rem 3rem 1rem 3rem' }} spacing={2}>
           <Stack direction="row" alignItems="center" justifyContent="space-between">
             <Breadcrumbs links={[{ title: 'Dashboard', href: '/dashboard' }, { title: workspace || '' }]} />
-            <ShareWorkspace workspace={workspace!} />
+            <Stack direction="row" spacing={1}>
+              <ShareWorkspace workspace={workspace!} />
+              <DeleteWorkspace workspace={workspace!} />
+            </Stack>
           </Stack>
           <Stack direction="row" alignItems="center" justifyContent="space-between">
             <MultiToggle style={{ fontSize: '1.5rem' }}>

--- a/src/services/workspace-service.ts
+++ b/src/services/workspace-service.ts
@@ -16,6 +16,13 @@ export class WorkspaceService {
       .then((res) => res.body as Workspace);
   }
 
+  public delete(workspace: Workspace) {
+    return requests
+      .delete(`api/v1/workspaces/`)
+      .send(workspace)
+      .then((res) => res.body as Workspace);
+  }
+
   public list() {
     return requests.get('api/v1/workspaces/').then((res) => res.body as WorkspaceList);
   }

--- a/src/styles/theme/theme-selector.tsx
+++ b/src/styles/theme/theme-selector.tsx
@@ -1,4 +1,5 @@
 import React, { FC, useContext } from 'react';
+import { ThemeProvider as OPTThemeProvider } from '@equinor/opt-ui-core';
 import { SettingsContextStore } from '../../common/context/editor-settings-context';
 import { lightTheme, darkTheme } from '.';
 import { ThemeProvider } from 'styled-components';
@@ -9,5 +10,11 @@ interface ThemeSelectorProps {
 
 export const ThemeSelector: FC<ThemeSelectorProps> = (props: ThemeSelectorProps) => {
   const { settings } = useContext(SettingsContextStore);
-  return <ThemeProvider theme={settings?.darkTheme ? darkTheme : lightTheme}>{props.children}</ThemeProvider>;
+  return (
+    <ThemeProvider theme={settings?.darkTheme ? darkTheme : lightTheme}>
+      <OPTThemeProvider theme={{ mode: settings?.darkTheme ? 'dark' : 'light' }}>
+        {props.children}
+      </OPTThemeProvider>
+    </ThemeProvider>
+  );
 };


### PR DESCRIPTION
PR for the [issue](https://github.com/equinor/flowify-workflows-UI/issues/93)

Workspace deletion
- in the workspace page delete button is present for a user with workspace editor permission
- confirmation modal to avoid deleting by mistake
- success notification and the page will display an empty state message "<workspace name> is not a valid workspace."